### PR TITLE
Fix HR session stability check

### DIFF
--- a/Arete Watch App/MeditationSessionView.swift
+++ b/Arete Watch App/MeditationSessionView.swift
@@ -84,9 +84,10 @@ struct MeditationSessionView<Store: HealthDataProviding>: View {
 
     private func startHRQuery() {
         guard HKHealthStore.isHealthDataAvailable(),
-              let store = HKHealthStore(),
               let type = HKQuantityType.quantityType(forIdentifier: .heartRate)
         else { return }
+
+        let store = HKHealthStore()
 
         let predicate = HKQuery.predicateForSamples(
             withStart: startDate, end: nil, options: []
@@ -113,7 +114,8 @@ struct MeditationSessionView<Store: HealthDataProviding>: View {
                 if hrSamples.count > requiredStableTime {
                     hrSamples.removeFirst(hrSamples.count - requiredStableTime)
                 }
-                if let minHR = hrSamples.min(),
+                if hrSamples.count >= requiredStableTime,
+                   let minHR = hrSamples.min(),
                    let maxHR = hrSamples.max(),
                    (maxHR - minHR) <= stabilityThreshold
                 {


### PR DESCRIPTION
## Summary
- fix unreachable `startHRQuery` guard by moving `HKHealthStore()` outside
- ensure heart rate stabilization requires 30 samples

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6854cea960e8832da6b034826b8d500e