### PR TITLE
Add post-meditation heart-rate graph (v2)

### DIFF
--- a/Arete Watch App/MeditationDetailView.swift
+++ b/Arete Watch App/MeditationDetailView.swift
@@ -3,9 +3,11 @@ import SwiftUI
 struct MeditationDetailView<Store: HealthDataProviding>: View {
     @ObservedObject var healthStore: Store
     @State private var showSession      = false
+    @State private var showResults      = false
     @State private var selectedDuration = 1
     @State private var useHRMode        = false
     @State private var showCustomPicker = false
+    @State private var recentHRSamples: [Double] = []
     
     let presetDurations = [1, 2, 5, 10, 30]
     let customRange     = Array(1...60)
@@ -67,11 +69,18 @@ struct MeditationDetailView<Store: HealthDataProviding>: View {
                 healthStore: healthStore,
                 durationMinutes: selectedDuration,
                 useHeartRateMode: useHRMode,
-                onComplete: {
+                onComplete: { samples in
                     healthStore.requestAuthorization()
                     showSession = false
+                    recentHRSamples = samples
+                    showResults = true
                 }
             )
+        }
+        .navigationDestination(isPresented: $showResults) {
+            MeditationResultsView(hrSamples: recentHRSamples) {
+                showResults = false
+            }
         }
     }
 }

--- a/Arete Watch App/MeditationResultsView.swift
+++ b/Arete Watch App/MeditationResultsView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+import Charts
+
+struct MeditationResultsView: View {
+    let hrSamples: [Double]
+    let onComplete: () -> Void
+
+    struct DataPoint: Identifiable {
+        let id: Int
+        let bpm: Double
+        let avg: Double
+    }
+
+    private var data: [DataPoint] {
+        var runningTotal = 0.0
+        return hrSamples.enumerated().map { idx, bpm in
+            runningTotal += bpm
+            let avg = runningTotal / Double(idx + 1)
+            return DataPoint(id: idx, bpm: bpm, avg: avg)
+        }
+    }
+
+    private var minHR: Double { hrSamples.min() ?? 0 }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Chart(data) { point in
+                PointMark(
+                    x: .value("Time", point.id),
+                    y: .value("BPM", point.bpm)
+                )
+                .foregroundStyle(.red)
+                .symbolSize(20)
+
+                LineMark(
+                    x: .value("Time", point.id),
+                    y: .value("Avg", point.avg)
+                )
+                .interpolationMethod(.monotone)
+                .foregroundStyle(.gray)
+                .lineStyle(StrokeStyle(lineWidth: 2))
+            }
+            .chartYAxis {
+                AxisMarks(position: .leading)
+            }
+            .chartYScale(domain: (minHR - 10)...((hrSamples.max() ?? 0) + 10))
+            .frame(height: 120)
+            .overlay {
+                RuleMark(y: .value("Min", minHR))
+                    .foregroundStyle(.blue)
+                    .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
+                    .annotation(position: .topTrailing) {
+                        Text("Min \(Int(minHR))")
+                            .font(.footnote)
+                            .foregroundStyle(.blue)
+                    }
+            }
+
+            Button("Complete") {
+                onComplete()
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    MeditationResultsView(hrSamples: [70, 68, 65, 64, 63, 62, 62, 63, 64]) {}
+}

--- a/Arete Watch App/MeditationSessionView.swift
+++ b/Arete Watch App/MeditationSessionView.swift
@@ -8,7 +8,7 @@ struct MeditationSessionView<Store: HealthDataProviding>: View {
     @ObservedObject var healthStore: Store
     let durationMinutes: Int
     let useHeartRateMode: Bool
-    let onComplete: () -> Void
+    let onComplete: ([Double]) -> Void
 
     // Timer mode state
     @State private var timeRemaining: Int
@@ -26,7 +26,7 @@ struct MeditationSessionView<Store: HealthDataProviding>: View {
     init(healthStore: Store,
          durationMinutes: Int,
          useHeartRateMode: Bool,
-         onComplete: @escaping () -> Void)
+         onComplete: @escaping ([Double]) -> Void)
     {
         self._healthStore       = ObservedObject(wrappedValue: healthStore)
         self.durationMinutes    = durationMinutes
@@ -140,7 +140,7 @@ struct MeditationSessionView<Store: HealthDataProviding>: View {
         playHaptic(.success)
         healthStore.logMindfulness(start: startDate, end: Date())
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-            onComplete()
+            onComplete(hrSamples)
         }
     }
 


### PR DESCRIPTION
## Summary
- capture heart rate samples when a meditation session ends
- show a results screen with a heart rate chart and Complete button

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6854d4525524832d942a9cc8d8525dba