### PR TITLE
Add meditation heart-rate summary (v1.1)

### DIFF
--- a/Arete Watch App/MeditationDetailView.swift
+++ b/Arete Watch App/MeditationDetailView.swift
@@ -6,6 +6,8 @@ struct MeditationDetailView<Store: HealthDataProviding>: View {
     @State private var selectedDuration = 1
     @State private var useHRMode        = false
     @State private var showCustomPicker = false
+    @State private var showSummary      = false
+    @State private var summaryPoints: [HRDataPoint] = []
     
     let presetDurations = [1, 2, 5, 10, 30]
     let customRange     = Array(1...60)
@@ -67,11 +69,18 @@ struct MeditationDetailView<Store: HealthDataProviding>: View {
                 healthStore: healthStore,
                 durationMinutes: selectedDuration,
                 useHeartRateMode: useHRMode,
-                onComplete: {
+                onComplete: { points in
                     healthStore.requestAuthorization()
+                    summaryPoints = points
                     showSession = false
+                    showSummary = true
                 }
             )
+        }
+        .navigationDestination(isPresented: $showSummary) {
+            MeditationSummaryView(points: summaryPoints) {
+                showSummary = false
+            }
         }
     }
 }

--- a/Arete Watch App/MeditationSummaryView.swift
+++ b/Arete Watch App/MeditationSummaryView.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+import Charts
+
+struct HRDataPoint: Identifiable {
+    let time: Double
+    let bpm: Double
+    var id: Double { time }
+}
+
+struct MeditationSummaryView: View {
+    let points: [HRDataPoint]
+    let onComplete: () -> Void
+
+    private var minBPM: Double? { points.map { $0.bpm }.min() }
+    private var avgPoints: [HRDataPoint] {
+        var running: [HRDataPoint] = []
+        var total = 0.0
+        for (i, p) in points.enumerated() {
+            total += p.bpm
+            let avg = total / Double(i + 1)
+            running.append(HRDataPoint(time: p.time, bpm: avg))
+        }
+        return running
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Chart {
+                if let min = minBPM {
+                    RuleMark(y: .value("Min", min))
+                        .foregroundStyle(.blue)
+                        .lineStyle(StrokeStyle(lineWidth: 1, dash: [4]))
+                        .annotation(position: .leading) {
+                            Text("min \(Int(min))")
+                                .font(.caption2)
+                                .foregroundColor(.blue)
+                        }
+                }
+
+                ForEach(points) { point in
+                    PointMark(
+                        x: .value("Time", point.time),
+                        y: .value("BPM", point.bpm)
+                    )
+                    .foregroundStyle(.red)
+                }
+
+                ForEach(avgPoints) { point in
+                    LineMark(
+                        x: .value("Time", point.time),
+                        y: .value("Avg", point.bpm)
+                    )
+                    .foregroundStyle(.green)
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+                }
+            }
+            .chartXAxisLabel("Time (s)")
+            .chartYAxisLabel("BPM")
+            .frame(height: 100)
+
+            Button("Complete") {
+                onComplete()
+            }
+        }
+        .padding()
+        .navigationBarBackButtonHidden(true)
+    }
+}
+
+#Preview {
+    MeditationSummaryView(points: [
+        HRDataPoint(time: 0, bpm: 80),
+        HRDataPoint(time: 10, bpm: 78),
+        HRDataPoint(time: 20, bpm: 70)
+    ]) {}
+}


### PR DESCRIPTION
## Summary
- add `MeditationSummaryView` for post-session heart‑rate graph
- capture HR samples with timestamps during sessions
- show summary after a session ends

## Testing
- `swiftc Arete\ Watch\ App/ContentView.swift -o /tmp/test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6854d4525524832d942a9cc8d8525dba